### PR TITLE
Removing bind_addr from params as this should be defined in the config…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,6 @@ class consul::params {
   $ui_download_url_base  = 'https://dl.bintray.com/mitchellh/consul/'
   $ui_download_extension = 'zip'
   $version               = '0.5.2'
-  $bind_addr             = $::ipaddress
 
   if $::operatingsystem != 'windows' {
     case $::architecture {

--- a/templates/make_service.ps1.erb
+++ b/templates/make_service.ps1.erb
@@ -4,7 +4,7 @@
 $consulTargetDir = "<%= scope['consul::params::package_target'] %>" -replace "/", "\"
 $consulExe = "`"" + $consulTargetDir + "\consul.exe`""
 $consulConfig = "`"`"agent -config-dir=`"<%= scope['consul::params::package_target'] %>" + "\config\`"`"`"" -replace "/", "\"
-$consulInstString = $consulExe + " " + $consulConfig + " " + "`"`"-bind=<%= scope['consul::params::bind_addr'] %>`"`""
+$consulInstString = $consulExe + " " + $consulConfig
 $consulErrLog = $consulTargetDir + "\logs\consul-err.log"
 $consulStdLog = $consulTargetDir + "\logs\consul.log"
 
@@ -12,7 +12,7 @@ $consulStdLog = $consulTargetDir + "\logs\consul.log"
 Set-Location $consulTargetDir
 
 ## build service:
-.\helper\nssm.exe install Consul $consulInstString 
+.\helper\nssm.exe install Consul $consulInstString
 .\helper\nssm.exe set Consul AppDirectory $consulTargetDir
 .\helper\nssm.exe set Consul DisplayName Consul
 .\helper\nssm.exe set Consul AppStopMethodConsole 15000


### PR DESCRIPTION
We shouldn't need the bind_addr on the command line instead this should be completely configured via the configuration files.
