### PR TITLE
Using config_dir instead of package_target

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,25 +87,17 @@ class consul::config(
     }
   }
 
-  if $::operatingsystem != 'windows' {
-    file { $consul::config_dir:
-      ensure  => 'directory',
-      owner   => $consul::user,
-      group   => $consul::group,
-      purge   => $purge,
-      recurse => $purge,
-    }
-    file { 'consul config.json':
-      ensure  => present,
-      path    => "${consul::config_dir}/config.json",
-      content => consul_sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
-    }
-  } else {
-    file { "${consul::params::package_target}/config/consul-agent.json":
-      ensure  => 'present',
-#      content => template('consul/consul.conf-json.erb'),
-      content => consul_sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
-    }
+  file { $consul::config_dir:
+    ensure  => 'directory',
+    owner   => $consul::user,
+    group   => $consul::group,
+    purge   => $purge,
+    recurse => $purge,
+  }
+  file { 'consul config.json':
+    ensure  => present,
+    path    => "${consul::config_dir}/config.json",
+    content => consul_sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
   }
 
 }

--- a/templates/make_service.ps1.erb
+++ b/templates/make_service.ps1.erb
@@ -1,9 +1,9 @@
 
 
 ## vars:
-$consulTargetDir = "<%= scope['consul::params::package_target'] %>" -replace "/", "\"
+$consulTargetDir = "<%= scope['consul::bin_dir'] %>" -replace "/", "\"
 $consulExe = "`"" + $consulTargetDir + "\consul.exe`""
-$consulConfig = "`"`"agent -config-dir=`"<%= scope['consul::params::package_target'] %>" + "\config\`"`"`"" -replace "/", "\"
+$consulConfig = "`"`"agent -config-dir=`"<%= scope['consul::config_dir'] %>" + "`"`"`"" -replace "/", "\"
 $consulInstString = $consulExe + " " + $consulConfig + " " + "`"`"-bind=<%= scope['consul::params::bind_addr'] %>`"`""
 $consulErrLog = $consulTargetDir + "\logs\consul-err.log"
 $consulStdLog = $consulTargetDir + "\logs\consul.log"
@@ -12,7 +12,7 @@ $consulStdLog = $consulTargetDir + "\logs\consul.log"
 Set-Location $consulTargetDir
 
 ## build service:
-.\helper\nssm.exe install Consul $consulInstString 
+.\helper\nssm.exe install Consul $consulInstString
 .\helper\nssm.exe set Consul AppDirectory $consulTargetDir
 .\helper\nssm.exe set Consul DisplayName Consul
 .\helper\nssm.exe set Consul AppStopMethodConsole 15000


### PR DESCRIPTION
We should be able to use the consistent config_dir, if you could double check the quotes escaped in the make service script that would help.  Wasn't sure how many of those were needed anymore.
